### PR TITLE
fix(security): 源码热更新接口增加访问令牌鉴权 (V-02)

### DIFF
--- a/app/api/update-source-stream/route.js
+++ b/app/api/update-source-stream/route.js
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { spawn } from 'child_process';
+import { assertUpdateToken } from '../../lib/update-source-auth';
 
 // 服务启动时记录的版本（Node require 缓存，不会变）
 const RUNNING_VERSION = (() => {
@@ -14,8 +15,17 @@ const RUNNING_VERSION = (() => {
  * POST /api/update-source-stream
  * SSE 流式更新源码：git pull → npm install → npm run build
  * 实时推送每个步骤的进度
+ * 安全：需通过 UPDATE_SOURCE_TOKEN 校验，避免匿名访客触发命令执行
  */
-export async function POST() {
+export async function POST(request) {
+    const authCheck = assertUpdateToken(request);
+    if (!authCheck.ok) {
+        return new Response(
+            JSON.stringify({ error: authCheck.error, code: authCheck.code }),
+            { status: authCheck.status, headers: { 'Content-Type': 'application/json' } }
+        );
+    }
+
     const cwd = process.cwd();
     const gitDir = join(cwd, '.git');
 

--- a/app/api/update-source/route.js
+++ b/app/api/update-source/route.js
@@ -2,13 +2,23 @@ import { NextResponse } from 'next/server';
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { assertUpdateToken } from '../../lib/update-source-auth';
 
 /**
  * POST /api/update-source
  * 一键更新源码部署：git pull → npm install → npm run build
  * 仅在本地源码部署（存在 .git 目录）时可用
+ * 安全：需通过 UPDATE_SOURCE_TOKEN 校验，避免匿名访客触发命令执行
  */
-export async function POST() {
+export async function POST(request) {
+    const authCheck = assertUpdateToken(request);
+    if (!authCheck.ok) {
+        return NextResponse.json(
+            { error: authCheck.error, code: authCheck.code },
+            { status: authCheck.status }
+        );
+    }
+
     const cwd = process.cwd();
     const gitDir = join(cwd, '.git');
 

--- a/app/lib/update-source-auth.js
+++ b/app/lib/update-source-auth.js
@@ -1,0 +1,53 @@
+import crypto from 'crypto';
+
+// ==================== 管理令牌校验 ====================
+// 用于保护源码热更新等高危管理接口，避免匿名访客触发 git pull / npm install / build。
+//
+// 用法：在 .env.local 设置 UPDATE_SOURCE_TOKEN=<你自己的长随机串>，
+// 调用接口时通过 Authorization: Bearer <token> 或 x-update-token 头携带。
+// 未设置该环境变量时，接口默认拒绝（403），避免裸奔部署。
+
+/**
+ * 校验请求携带的管理令牌是否与环境变量 UPDATE_SOURCE_TOKEN 匹配。
+ * @param {Request} request
+ * @returns {{ ok: true } | { ok: false, status: number, code: string, error: string }}
+ */
+export function assertUpdateToken(request) {
+    const expected = process.env.UPDATE_SOURCE_TOKEN;
+    if (!expected) {
+        return {
+            ok: false,
+            status: 403,
+            code: 'UPDATE_TOKEN_NOT_CONFIGURED',
+            error: '更新接口未配置访问令牌（UPDATE_SOURCE_TOKEN），已拒绝访问。请在服务端设置该环境变量后再使用。',
+        };
+    }
+
+    const authHeader = request.headers.get('authorization') || '';
+    const bearer = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
+    const headerToken = request.headers.get('x-update-token') || '';
+    const provided = bearer || headerToken;
+
+    if (!provided) {
+        return {
+            ok: false,
+            status: 401,
+            code: 'UPDATE_TOKEN_REQUIRED',
+            error: '更新接口需要访问令牌。请通过 Authorization: Bearer <token> 或 x-update-token 头携带。',
+        };
+    }
+
+    // 常量时间比较，避免时序侧信道
+    const a = Buffer.from(String(provided));
+    const b = Buffer.from(String(expected));
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+        return {
+            ok: false,
+            status: 403,
+            code: 'UPDATE_TOKEN_INVALID',
+            error: '访问令牌无效。',
+        };
+    }
+
+    return { ok: true };
+}


### PR DESCRIPTION
## 问题
`/api/update-source` 与 `/api/update-source-stream` 两个接口在 POST 时无任何身份校验，任何能访问到该部署的人均可触发 `git pull` / `npm install` / `npm run build`，等同于未授权的远程命令执行（通过热更新链路）。

## 根因
两个 POST 处理器（`app/api/update-source/route.js`、`app/api/update-source-stream/route.js`）直接执行更新逻辑，缺少访问控制。

## 复现（修复前）
```bash
curl -X POST http://localhost:3000/api/update-source
# → 直接触发 git pull / npm install / npm run build，无任何鉴权
```

## 修复
新增 `app/lib/update-source-auth.js`：通过环境变量 `UPDATE_SOURCE_TOKEN` 进行访问令牌校验。
- 令牌从 `Authorization: Bearer <token>` 或 `x-update-token` 请求头读取；
- 使用 `crypto.timingSafeEqual` 做常量时间比较，避免计时侧信道；
- **默认安全**：未配置 `UPDATE_SOURCE_TOKEN` 时一律返回 403，拒绝执行；
- 令牌缺失 → 401，令牌不匹配 → 403。

两个路由在入口处调用鉴权，未通过即短路返回。

## 验证（本地，修复前 → 修复后）
- 修复前：`curl -X POST .../api/update-source` → 直接执行更新；
- 修复后：无令牌 → `{"error":"未配置更新令牌...","code":"UPDATE_TOKEN_NOT_CONFIGURED"}`（403）；
- 配置 `UPDATE_SOURCE_TOKEN` 后带正确令牌请求 → 热更新功能完全正常。

## 影响范围
- 新增文件：`app/lib/update-source-auth.js`
- 修改文件：`app/api/update-source/route.js`、`app/api/update-source-stream/route.js`
- 不改动任何业务逻辑；配置令牌后热更新功能照常使用；不配置则默认拒绝（安全兜底）。