### PR TITLE
fix(security): AI 代理路由群增加上游地址校验防 SSRF (V-01)

### DIFF
--- a/app/api/ai/claude/route.js
+++ b/app/api/ai/claude/route.js
@@ -7,6 +7,7 @@ export const maxDuration = 120;
 import { applyContentSafety } from '../../../lib/content-safety';
 import { proxyFetch } from '../../../lib/proxy-fetch';
 import { rotateKey } from '../../../lib/keyRotator';
+import { assertUpstreamUrl } from '../../../lib/upstream-guard';
 
 // Anthropic 格式的搜索工具定义
 const WEB_SEARCH_TOOL = {
@@ -72,6 +73,15 @@ export async function POST(request) {
             return new Response(
                 JSON.stringify({ error: '请先填写 Claude 兼容 API 地址', code: 'NO_BASE_URL_CLAUDE' }),
                 { status: 400, headers: { 'Content-Type': 'application/json' } }
+            );
+        }
+
+        // SSRF 防护：校验用户可控的 baseUrl（仅放行公网 http/https；本机请求可放行私网）
+        const guard = assertUpstreamUrl(baseUrl, request);
+        if (!guard.ok) {
+            return new Response(
+                JSON.stringify({ error: guard.error, code: guard.code }),
+                { status: guard.status, headers: { 'Content-Type': 'application/json' } }
             );
         }
 

--- a/app/api/ai/gemini/route.js
+++ b/app/api/ai/gemini/route.js
@@ -7,6 +7,7 @@ export const maxDuration = 120;
 import { applyContentSafety } from '../../../lib/content-safety';
 import { proxyFetch } from '../../../lib/proxy-fetch';
 import { rotateKey } from '../../../lib/keyRotator';
+import { assertUpstreamUrl } from '../../../lib/upstream-guard';
 
 export async function POST(request) {
     try {
@@ -29,6 +30,15 @@ export async function POST(request) {
             return new Response(
                 JSON.stringify({ error: '请先填写 Gemini 原生 API 地址（通常以 /v1beta 结尾）', code: 'NO_BASE_URL_GEMINI' }),
                 { status: 400, headers: { 'Content-Type': 'application/json' } }
+            );
+        }
+
+        // SSRF 防护：校验用户可控的 baseUrl（仅放行公网 http/https；本机请求可放行私网）
+        const guard = assertUpstreamUrl(baseUrl, request);
+        if (!guard.ok) {
+            return new Response(
+                JSON.stringify({ error: guard.error, code: guard.code }),
+                { status: guard.status, headers: { 'Content-Type': 'application/json' } }
             );
         }
 

--- a/app/api/ai/models/route.js
+++ b/app/api/ai/models/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { proxyFetch } from '../../../lib/proxy-fetch';
 import { rotateKey } from '../../../lib/keyRotator';
+import { assertUpstreamUrl } from '../../../lib/upstream-guard';
 
 // 通用模型列表拉取 — OpenAI 兼容 / Claude 兼容 / Gemini 原生
 export async function POST(request) {
@@ -17,16 +18,16 @@ export async function POST(request) {
 
         // Gemini 原生格式
         if (provider === 'gemini-native') {
-            return await fetchGeminiModels(apiKey, baseUrl, embedOnly, proxyUrl);
+            return await fetchGeminiModels(apiKey, baseUrl, embedOnly, proxyUrl, request);
         }
 
         // Claude 兼容格式
         if (provider === 'claude') {
-            return await fetchClaudeModels(apiKey, baseUrl, proxyUrl);
+            return await fetchClaudeModels(apiKey, baseUrl, proxyUrl, request);
         }
 
         // OpenAI 兼容格式（适用于所有其他供应商）
-        return await fetchOpenAIModels(apiKey, baseUrl, embedOnly, provider, proxyUrl);
+        return await fetchOpenAIModels(apiKey, baseUrl, embedOnly, provider, proxyUrl, request);
 
     } catch (error) {
         console.error('拉取模型列表错误:', error);
@@ -103,13 +104,19 @@ function normalizeOpenAIBaseUrl(rawBaseUrl) {
     return base;
 }
 
-async function fetchOpenAIModels(apiKey, baseUrl, embedOnly, provider, proxyUrl) {
+async function fetchOpenAIModels(apiKey, baseUrl, embedOnly, provider, proxyUrl, request) {
     const base = normalizeOpenAIBaseUrl(baseUrl);
     if (!base) {
         return NextResponse.json(
             { error: '请先填写 API 地址', code: 'NO_BASE_URL' },
             { status: 400 }
         );
+    }
+
+    // SSRF 防护：校验用户可控的 baseUrl（仅放行公网 http/https；本机请求可放行私网）
+    const guard = assertUpstreamUrl(base, request);
+    if (!guard.ok) {
+        return NextResponse.json({ error: guard.error, code: guard.code }, { status: guard.status });
     }
 
     const headers = {
@@ -226,10 +233,16 @@ async function handleFetchError(response) {
 }
 
 // Claude 兼容模型列表（Anthropic /v1/models 协议）
-async function fetchClaudeModels(apiKey, baseUrl, proxyUrl) {
+async function fetchClaudeModels(apiKey, baseUrl, proxyUrl, request) {
     const base = String(baseUrl || '').trim().replace(/\/+$/, '');
     if (!base) {
         return NextResponse.json({ error: '请先填写 Claude 兼容 API 地址', code: 'NO_BASE_URL_CLAUDE' }, { status: 400 });
+    }
+
+    // SSRF 防护：校验用户可控的 baseUrl（仅放行公网 http/https；本机请求可放行私网）
+    const guard = assertUpstreamUrl(base, request);
+    if (!guard.ok) {
+        return NextResponse.json({ error: guard.error, code: guard.code }, { status: guard.status });
     }
 
     const endpoint = base.endsWith('/v1') ? base + '/models?limit=100' : base + '/v1/models?limit=100';
@@ -266,10 +279,16 @@ async function fetchClaudeModels(apiKey, baseUrl, proxyUrl) {
 }
 
 // Gemini 原生格式模型列表 — 分页拉取（不内置官方默认地址，baseUrl 必填）
-async function fetchGeminiModels(apiKey, baseUrl, embedOnly, proxyUrl) {
+async function fetchGeminiModels(apiKey, baseUrl, embedOnly, proxyUrl, request) {
     const base = String(baseUrl || '').trim().replace(/\/+$/, '');
     if (!base) {
         return NextResponse.json({ error: '请先填写 Gemini 原生 API 地址（通常以 /v1beta 结尾）', code: 'NO_BASE_URL_GEMINI' }, { status: 400 });
+    }
+
+    // SSRF 防护：校验用户可控的 baseUrl（仅放行公网 http/https；本机请求可放行私网）
+    const guard = assertUpstreamUrl(base, request);
+    if (!guard.ok) {
+        return NextResponse.json({ error: guard.error, code: guard.code }, { status: guard.status });
     }
 
     let allModels = [];

--- a/app/api/ai/route.js
+++ b/app/api/ai/route.js
@@ -8,6 +8,7 @@ export const maxDuration = 120;
 import { applyContentSafety } from '../../lib/content-safety';
 import { proxyFetch } from '../../lib/proxy-fetch';
 import { rotateKey } from '../../lib/keyRotator';
+import { assertUpstreamUrl } from '../../lib/upstream-guard';
 
 // Function Calling 搜索工具定义
 const WEB_SEARCH_TOOL = {
@@ -135,6 +136,15 @@ export async function POST(request) {
             return new Response(
                 JSON.stringify({ error: '请先填写 OpenAI 兼容端点地址（通常以 /v1 结尾）', code: 'NO_BASE_URL_OPENAI' }),
                 { status: 400, headers: { 'Content-Type': 'application/json' } }
+            );
+        }
+
+        // SSRF 防护：校验用户可控的 baseUrl（仅放行公网 http/https；本机请求可放行私网）
+        const guard = assertUpstreamUrl(baseUrl, request);
+        if (!guard.ok) {
+            return new Response(
+                JSON.stringify({ error: guard.error, code: guard.code }),
+                { status: guard.status, headers: { 'Content-Type': 'application/json' } }
             );
         }
 

--- a/app/api/ai/test/route.js
+++ b/app/api/ai/test/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { proxyFetch } from '../../../lib/proxy-fetch';
 import { rotateKey } from '../../../lib/keyRotator';
+import { assertUpstreamUrl } from '../../../lib/upstream-guard';
 
 const DEEPSEEK_V4_MODELS = new Set(['deepseek-v4-pro', 'deepseek-v4-flash']);
 
@@ -22,6 +23,11 @@ export async function POST(request) {
         }
         if (!baseUrl) {
             return NextResponse.json({ success: false, error: '请先填写兼容 API 地址', code: 'NO_BASE_URL_COMPAT' }, { status: 400 });
+        }
+        // SSRF 防护：校验用户可控的 baseUrl（仅放行公网 http/https；本机请求可放行私网）
+        const guard = assertUpstreamUrl(baseUrl, request);
+        if (!guard.ok) {
+            return NextResponse.json({ success: false, error: guard.error, code: guard.code }, { status: guard.status });
         }
         if (provider === 'claude' || apiFormat === 'anthropic') {
             return await testClaudeCompatible(apiKey, baseUrl, model, proxyUrl);

--- a/app/api/balance/route.js
+++ b/app/api/balance/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { proxyFetch } from '../../lib/proxy-fetch';
 import { rotateKey } from '../../lib/keyRotator';
+import { assertUpstreamUrl } from '../../lib/upstream-guard';
 
 export const runtime = 'nodejs';
 
@@ -19,6 +20,14 @@ export async function POST(request) {
         }
 
         const effectiveBaseUrl = (baseUrl || '').replace(/\/+$/, '');
+
+        // SSRF 防护：校验用户可控的 baseUrl（仅放行公网 http/https；本机请求可放行私网）
+        if (effectiveBaseUrl) {
+            const guard = assertUpstreamUrl(effectiveBaseUrl, request);
+            if (!guard.ok) {
+                return NextResponse.json({ error: guard.error, code: guard.code }, { status: guard.status });
+            }
+        }
 
         // 有专用接口的已知供应商列表
         const knownProviders = ['deepseek', 'siliconflow', 'moonshot'];

--- a/app/api/embed/route.js
+++ b/app/api/embed/route.js
@@ -4,45 +4,28 @@ export const runtime = 'nodejs';
 
 import { proxyFetch } from '../../lib/proxy-fetch';
 import { rotateKey } from '../../lib/keyRotator';
+import { assertUpstreamUrl } from '../../lib/upstream-guard';
 
-function readErrorDetail(errorText) {
-    try {
-        const parsed = JSON.parse(errorText);
-        const detail = parsed?.error?.message || parsed?.errors?.message || parsed?.error || parsed?.errors || parsed?.message;
-        if (!detail) return errorText;
-        return typeof detail === 'string' ? detail : JSON.stringify(detail);
-    } catch {
-        return errorText;
-    }
-}
-
-async function embeddingErrorResponse(response, { provider, model }) {
-    const detail = readErrorDetail(await response.text());
-    let hint = '';
+// SSRF 防护：错误响应不再回显上游原始响应体，避免把内网服务返回内容泄露给客户端
+function safeEmbedFailure(status, { provider, model }) {
     let hintCode = '';
-
-    if (response.status === 401 || response.status === 403) {
-        hintCode = 'EMBED_HINT_AUTH';
-        hint = '请检查 Embedding API Key 是否正确，并确认该 Key 有调用当前嵌入模型的权限。';
-    } else if (response.status === 404) {
-        hintCode = 'EMBED_HINT_ADDR';
-        hint = '请检查 Embedding API 地址是否正确。OpenAI 兼容地址通常需要包含 /v1，最终会请求 /embeddings。';
-    } else if (response.status === 429) {
-        hintCode = 'EMBED_HINT_RATE';
-        hint = '请求过于频繁或额度不足，请稍后重试，或降低重建频率。';
-    }
-
-    const prefix = `${provider || 'Embedding'} 模型 ${model || '未指定'} 调用失败 (${response.status})`;
-    // 保留中文兜底全文（无 code 的消费方仍可读）；同时返回结构化字段供前端按 code 本地化
+    if (status === 401 || status === 403) hintCode = 'EMBED_HINT_AUTH';
+    else if (status === 404) hintCode = 'EMBED_HINT_ADDR';
+    else if (status === 429) hintCode = 'EMBED_HINT_RATE';
+    const hintMap = {
+        EMBED_HINT_AUTH: '请检查 Embedding API Key 是否正确，并确认该 Key 有调用当前嵌入模型的权限。',
+        EMBED_HINT_ADDR: '请检查 Embedding API 地址是否正确。OpenAI 兼容地址通常需要包含 /v1，最终会请求 /embeddings。',
+        EMBED_HINT_RATE: '请求过于频繁或额度不足，请稍后重试，或降低重建频率。',
+    };
+    const prefix = `${provider || 'Embedding'} 模型 ${model || '未指定'} 调用失败 (${status})`;
     return Response.json({
-        error: [prefix, detail, hint].filter(Boolean).join('：'),
+        error: [prefix, hintMap[hintCode]].filter(Boolean).join('：'),
         code: 'EMBED_CALL_FAILED',
         provider: provider || '',
         model: model || '',
-        status: response.status,
-        detail: detail || '',
+        status,
         hintCode,
-    }, { status: response.status });
+    }, { status });
 }
 
 function invalidEmbeddingResponse(provider, model) {
@@ -102,6 +85,12 @@ export async function POST(request) {
             ? (apiConfig.embedModel || getDefaultEmbeddingModel(provider))
             : (apiConfig.embedModel || getDefaultEmbeddingModel(provider));
 
+        // SSRF 防护：校验用户可控的 baseUrl（仅放行公网 http/https；本机请求可放行私网）
+        const guard = assertUpstreamUrl(baseUrl, request);
+        if (!guard.ok) {
+            return Response.json({ error: guard.error, code: guard.code }, { status: guard.status });
+        }
+
         if (!embedModelName) {
             return Response.json({ error: '请先选择或填写 Embedding 模型', code: 'NO_EMBED_MODEL' }, { status: 400 });
         }
@@ -146,7 +135,7 @@ export async function POST(request) {
         }
 
         if (lastErrorResponse) {
-            return embeddingErrorResponse(lastErrorResponse, { provider, model: embedModelName });
+            return safeEmbedFailure(lastErrorResponse.status, { provider, model: embedModelName });
         }
         return invalidEmbeddingResponse(provider, embedModelName);
     } catch (error) {

--- a/app/api/tts/discover/route.js
+++ b/app/api/tts/discover/route.js
@@ -1,6 +1,7 @@
 export const runtime = 'nodejs';
 
 import { proxyFetch } from '../../../lib/proxy-fetch';
+import { assertUpstreamUrl } from '../../../lib/upstream-guard';
 
 const OPENAI_COMMON_VOICES = ['alloy', 'ash', 'ballad', 'coral', 'echo', 'fable', 'nova', 'onyx', 'sage', 'shimmer', 'verse'];
 const GEMINI_COMMON_VOICES = ['Kore', 'Puck', 'Charon', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr'];
@@ -27,10 +28,19 @@ function joinUrl(baseUrl, suffix) {
     return `${baseUrl.replace(/\/+$/, '')}/${String(suffix || '').replace(/^\/+/, '')}`;
 }
 
-function discoveryRoot(provider, config) {
+function discoveryRoot(provider, config, request) {
     const raw = provider === 'gemini' ? config?.baseUrl : config?.endpoint;
-    const normalized = normalizeUrl(raw);
+    let normalized;
+    try {
+        normalized = normalizeUrl(raw);
+    } catch (e) {
+        // 地址格式/协议错误，统一抛出供上层 catch 返回
+        throw new Error(e.message || 'TTS 地址无效');
+    }
     if (!normalized) return '';
+    // SSRF 防护：拒绝私网/保留/元数据地址（本机请求可放行私网）
+    const guard = assertUpstreamUrl(normalized, request);
+    if (!guard.ok) throw new Error(guard.error);
     const url = new URL(normalized);
     let pathname = url.pathname.replace(/\/+$/, '');
     if (provider === 'gemini') {
@@ -46,8 +56,8 @@ function discoveryRoot(provider, config) {
     return url.toString().replace(/\/+$/, '');
 }
 
-function discoveryEndpoints(provider, config) {
-    const root = discoveryRoot(provider, config);
+function discoveryEndpoints(provider, config, request) {
+    const root = discoveryRoot(provider, config, request);
     if (!root) return { models: [], voices: [] };
     const rootPath = new URL(root).pathname.replace(/\/+$/, '');
     const hasVersion = /\/v\d+(?:beta\d*)?$/i.test(rootPath);
@@ -191,7 +201,7 @@ export async function POST(request) {
             return jsonError('请先填写此音源的 API Key');
         }
 
-        const endpoints = discoveryEndpoints(provider, config);
+        const endpoints = discoveryEndpoints(provider, config, request);
         if (endpoints.models.length === 0) return jsonError('请先填写 TTS 接口地址');
         const headers = requestHeaders(provider, config, apiKey);
         const modelResult = await fetchCandidates(endpoints.models, headers, config.proxyUrl, 'models');

--- a/app/api/tts/route.js
+++ b/app/api/tts/route.js
@@ -1,6 +1,7 @@
 export const runtime = 'nodejs';
 
 import { proxyFetch } from '../../lib/proxy-fetch';
+import { assertUpstreamUrl } from '../../lib/upstream-guard';
 
 const GEMINI_MODEL = 'gemini-3.1-flash-tts-preview';
 
@@ -14,6 +15,15 @@ function normalizeUrl(value) {
     const url = new URL(raw);
     if (!['http:', 'https:'].includes(url.protocol)) throw new Error('TTS 地址只支持 HTTP 或 HTTPS');
     return url.toString().replace(/\/+$/, '');
+}
+
+// SSRF 防护：在 normalizeUrl 之上叠加主机校验，拒绝私网/保留/元数据地址
+function guardTtsUrl(value, request) {
+    const normalized = normalizeUrl(value);
+    if (!normalized) return '';
+    const guard = assertUpstreamUrl(normalized, request);
+    if (!guard.ok) throw new Error(guard.error);
+    return normalized;
 }
 
 function readPath(source, path) {
@@ -68,9 +78,14 @@ function audioResponse(buffer, contentType) {
     });
 }
 
-async function requestOpenAICompatible(input, config, apiKey) {
+async function requestOpenAICompatible(input, config, apiKey, request) {
     if (!apiKey) return errorResponse('请先在本机填写 OpenAI 兼容 API Key');
-    const endpoint = normalizeUrl(config.endpoint);
+    let endpoint;
+    try {
+        endpoint = guardTtsUrl(config.endpoint, request);
+    } catch (e) {
+        return errorResponse(e.message || 'OpenAI 兼容 TTS 地址无效');
+    }
     if (!endpoint) return errorResponse('请先填写 OpenAI 兼容 TTS 完整接口地址');
     const model = String(config.model || 'tts-1').trim();
     const voice = String(config.voice || 'alloy').trim();
@@ -99,9 +114,14 @@ async function requestOpenAICompatible(input, config, apiKey) {
     );
 }
 
-async function requestGemini(input, config, apiKey) {
+async function requestGemini(input, config, apiKey, request) {
     if (!apiKey) return errorResponse('请先在本机填写 Gemini 兼容 API Key');
-    const baseUrl = normalizeUrl(config.baseUrl);
+    let baseUrl;
+    try {
+        baseUrl = guardTtsUrl(config.baseUrl, request);
+    } catch (e) {
+        return errorResponse(e.message || 'Gemini 兼容 TTS 地址无效');
+    }
     if (!baseUrl) return errorResponse('请先填写 Gemini 兼容 API Base URL');
     const model = String(config.model || GEMINI_MODEL).trim();
     const voice = String(config.voice || 'Kore').trim();
@@ -140,8 +160,13 @@ function customHeaders(config, apiKey, provider) {
     return headers;
 }
 
-async function requestCustom(input, config, apiKey, provider) {
-    const endpoint = normalizeUrl(config.endpoint);
+async function requestCustom(input, config, apiKey, provider, request) {
+    let endpoint;
+    try {
+        endpoint = guardTtsUrl(config.endpoint, request);
+    } catch (e) {
+        return errorResponse(e.message || '兼容 TTS 地址无效');
+    }
     if (!endpoint) return errorResponse('请先填写兼容 TTS 完整接口地址');
     const authType = provider === 'anthropic-custom' ? 'x-api-key' : (config.authType || 'bearer');
     if (authType !== 'none' && !apiKey) return errorResponse('请先在本机填写此接口的 API Key');
@@ -176,9 +201,9 @@ export async function POST(request) {
         if (!input) return errorResponse('没有可朗读的文字');
         if (input.length > 5000) return errorResponse('单次朗读文字过长，请分段发送');
         if (!config.licenseConfirmed) return errorResponse('请先确认你拥有该音源及输出内容的使用授权');
-        if (provider === 'openai-compatible') return await requestOpenAICompatible(input, config, apiKey);
-        if (provider === 'gemini') return await requestGemini(input, config, apiKey);
-        if (provider === 'anthropic-custom' || provider === 'custom') return await requestCustom(input, config, apiKey, provider);
+        if (provider === 'openai-compatible') return await requestOpenAICompatible(input, config, apiKey, request);
+        if (provider === 'gemini') return await requestGemini(input, config, apiKey, request);
+        if (provider === 'anthropic-custom' || provider === 'custom') return await requestCustom(input, config, apiKey, provider, request);
         return errorResponse('不支持的 TTS 音源类型');
     } catch (error) {
         return errorResponse(error?.message || 'TTS 请求失败', 500);

--- a/app/lib/upstream-guard.js
+++ b/app/lib/upstream-guard.js
@@ -1,0 +1,101 @@
+// ==================== 上游地址安全校验（SSRF 防护）====================
+// 用于 AI 代理路由群：在服务端 fetch 用户可控的 baseUrl / endpoint 之前，
+// 校验协议与目标主机，拒绝指向本机/内网/保留段/云元数据的地址，
+// 避免匿名访客把服务器当作开放代理探测内网或窃取云元数据。
+//
+// 设计与 app/api/sync/webdav/route.js 的 isLocalHost()/isLocalRequest() 思路一致：
+// 仅当请求来自本机时才允许私网目标（本机开发联调本地模型）；
+// 公网部署下私网/保留地址一律拒绝。
+// 仅允许 http/https 协议；生产环境（非本机请求）强制 https 不在此处硬性要求，
+// 以兼容部分自建中转的 http，但保留地址与元数据地址在任何情况下都拒绝。
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0']);
+
+// 判断主机名是否为私网/保留/元数据地址
+function isPrivateHost(hostname) {
+    const host = String(hostname || '').toLowerCase().replace(/^\[|\]$/g, '');
+    if (!host) return true;
+    if (LOOPBACK_HOSTNAMES.has(host)) return true;
+    if (host.endsWith('.local') || host.endsWith('.internal')) return true;
+
+    // IPv4 私网/保留段
+    if (/^10\./.test(host)) return true;
+    if (/^192\.168\./.test(host)) return true;
+    if (/^172\.(1[6-9]|2\d|3[0-1])\./.test(host)) return true;
+    if (/^169\.254\./.test(host)) return true;          // 链路本地 + 云元数据 169.254.169.254
+    if (/^0\./.test(host)) return true;
+    if (/^100\.(6[4-9]|[7-9]\d|1[0-1]\d|12[0-7])\./.test(host)) return true; // CGNAT 100.64/10
+    if (/^198\.(1[8-9])\./.test(host)) return true;      // 198.18/15 基准测试
+    if (/^255\./.test(host)) return true;                // 广播
+
+    // IPv6 私网/保留/链路本地
+    if (host === '::' || host === '::1') return true;
+    if (host.startsWith('fc') || host.startsWith('fd')) return true;   // ULA
+    if (host.startsWith('fe80')) return true;                          // 链路本地
+    if (host.startsWith('::ffff:')) {
+        // IPv4-mapped IPv6，取出内嵌 IPv4 再判一次
+        const v4 = host.slice('::ffff:'.length);
+        if (/^\d+\.\d+\.\d+\.\d+$/.test(v4)) return isPrivateHost(v4);
+    }
+    return false;
+}
+
+// 判断本次请求是否来自本机/内网（参考 webdav/route.js 的 isLocalRequest，
+// 并叠加 Host 头校验：若客户端 Host 头显式指向公网域名，则视为公网请求，
+// 避免本地伪造 Host 头绕过；生产环境 request.url 通常已是公网域名，同样判为非本机）
+function isLocalRequest(requestUrl, hostHeader) {
+    let urlHost = '';
+    try {
+        urlHost = new URL(requestUrl).hostname;
+    } catch {
+        urlHost = '';
+    }
+    const headerHost = String(hostHeader || '').split(':')[0].trim();
+
+    // request.url 的主机名判本机/内网
+    const urlIsLocal = urlHost ? isPrivateHost(urlHost) : false;
+    // Host 头存在且为公网域名 → 视为公网请求
+    const headerIsPublic = headerHost ? !isPrivateHost(headerHost) : false;
+
+    if (headerIsPublic) return false;
+    return urlIsLocal || (LOOPBACK_HOSTNAMES.has(headerHost));
+}
+
+/**
+ * 校验用户提供的上游 URL 是否允许服务端发起请求。
+ * @param {string} rawUrl  用户可控的 baseUrl / endpoint
+ * @param {Request} request  当前请求对象（用于判断是否本机调用，决定是否放行私网）
+ * @returns {{ ok: true, url: string } | { ok: false, status: number, code: string, error: string }}
+ */
+export function assertUpstreamUrl(rawUrl, request) {
+    const raw = String(rawUrl || '').trim();
+    if (!raw) {
+        return { ok: false, status: 400, code: 'NO_BASE_URL', error: '请先填写上游 API 地址' };
+    }
+
+    let parsed;
+    try {
+        parsed = new URL(raw);
+    } catch {
+        return { ok: false, status: 400, code: 'INVALID_UPSTREAM_URL', error: '上游 API 地址格式无效' };
+    }
+
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return { ok: false, status: 400, code: 'UPSTREAM_UNSUPPORTED_SCHEME', error: '上游地址只支持 http 或 https' };
+    }
+
+    if (isPrivateHost(parsed.hostname)) {
+        // 仅当请求来自本机时允许私网目标（本机开发联调本地模型）
+        const fromLocal = request ? isLocalRequest(request.url, request.headers?.get?.('host')) : false;
+        if (!fromLocal) {
+            return {
+                ok: false,
+                status: 400,
+                code: 'UPSTREAM_PRIVATE_BLOCKED',
+                error: '上游地址指向本机或内网/保留地址，公网部署不允许代理访问',
+            };
+        }
+    }
+
+    return { ok: true, url: parsed.toString() };
+}


### PR DESCRIPTION
## 问题
9 个 AI 代理路由（`/api/ai`、`/api/ai/claude`、`/api/ai/gemini`、`/api/ai/models`、`/api/ai/test`、`/api/balance`、`/api/embed`、`/api/tts`、`/api/tts/discover`）直接用用户传入的 `baseUrl` / `endpoint` 发起服务端请求，可被导向内网地址或云元数据端点（如 `169.254.169.254`），构成 SSRF，可探测内网甚至读取云实例凭据。其中 `/api/embed` 还把上游响应体回显进 `detail` 字段，形成可读 SSRF。

## 根因
缺少对用户可控上游地址的协议白名单与私网 / 保留 / 元数据地址过滤。

## 复现（修复前）
本地起一个 echo server（端口 8743），将 AI 的 `baseUrl` 指向 `http://127.0.0.1:8743` 或 `http://169.254.169.254/...` 后调用相关路由，echo server 收到请求（证明服务端被导向了内部/元数据目标）。

## 修复
新增 `app/lib/upstream-guard.js`（`assertUpstreamUrl(rawUrl, request)`）：
- 协议白名单：仅允许 `http` / `https`；
- 阻断私网（10. / 192.168. / 172.16-31.）、保留（0. / 255.）、链路本地（169.254.）、CGNAT（100.64-127.）、基准测试（198.18-19.）、IPv6 ULA（fc/fd）、fe80 链路本地、`::ffff:` 映射地址，以及云元数据端点 `169.254.169.254`；
- **本地请求放行**：当请求来自本机（dev 服务器或自建单机部署）时允许访问本地模型，保证开发体验；
- 复用了仓库 webdav 路由的 `isLocalHost` 判定思路。

各路由在拼装真实 URL 前调用 guard，未通过即返回结构化错误（`UPSTREAM_PRIVATE_BLOCKED` / `UPSTREAM_UNSUPPORTED_SCHEME` 等，前端 `localizeApiError` 可按 code 本地化）。
另外 `/api/embed` 移除了把上游响应体写入 `detail` 的逻辑，关闭可读 SSRF 回显。

## 验证（本地，修复前 → 修复后）
- 修复前：将 `baseUrl` 指向 `127.0.0.1:8743` / `169.254.169.254` 的请求能到达 echo server；
- 修复后：9 个路由对私网/元数据目标全部返回阻断错误，echo server 无命中（diff = 0）；
- 合法公网 provider（如 `https://api.deepseek.com`、`https://api.anthropic.com`、`https://generativelanguage.googleapis.com`）正常放行；
- 本地开发访问本地模型仍可用。

## 影响范围
- 新增文件：`app/lib/upstream-guard.js`
- 修改文件：上述 9 个路由 + `/api/embed` 精简错误回显
- 正常 AI / 嵌入 / TTS / 余额 / 模型列表调用不受影响；仅拦截指向私网与元数据地址的可疑请求。