### PR TITLE
fix(security): 客户端 XSS 硬化——链接协议白名单与导出标题转义 (V-04)

### DIFF
--- a/app/components/HelpPanel.js
+++ b/app/components/HelpPanel.js
@@ -2355,8 +2355,15 @@ function renderSimpleMarkdown(md) {
     // Blockquote
     html = html.replace(/^> (.+)$/gm, '<blockquote>$1</blockquote>');
 
-    // Links [text](url)
-    html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+    // Links [text](url) — 仅允许 http/https/mailto 协议，拒绝 javascript:/data: 等可执行协议
+    html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) => {
+        const trimmedUrl = String(url || '').trim();
+        if (/^(https?:|mailto:)/i.test(trimmedUrl)) {
+            return `<a href="${trimmedUrl}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+        }
+        // 非白名单协议：去掉可执行性，仅保留可见文字
+        return text;
+    });
 
     // List items  
     html = html.replace(/^- (.+)$/gm, '<li>$1</li>');

--- a/app/lib/settings-io.js
+++ b/app/lib/settings-io.js
@@ -793,7 +793,11 @@ export async function parsePdfToText(file) {
  */
 export function exportSettingsAsPdf(nodes) {
     const workNode = nodes.find(n => n.type === 'work');
-    const title = `${workNode?.name || '设定集'} — 设定集`;
+    // 转义作品名（用户可控），避免 </title> / </h1> 上下文逃逸执行脚本
+    const safeWorkName = String(workNode?.name || '设定集')
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    const title = `${safeWorkName} — 设定集`;
 
     let html = '';
     const knownCategories = ['character', 'location', 'world', 'object', 'plot', 'rules'];


### PR DESCRIPTION
## 问题
1. 帮助面板 `HelpPanel` 的轻量 Markdown 渲染把链接 URL 原样写入 `<a href>`，`javascript:` / `data:` / `vbscript:` 等可执行协议可触发 XSS；
2. 导出 PDF 时作品名未经 HTML 转义直接写入 `<title>`，可逃逸出 title 上下文注入脚本。

## 根因
链接协议缺少白名单；导出标题缺少 HTML 转义。

## 复现（修复前）
- 含 `[点击](javascript:alert(document.cookie))` 的内容渲染后，链接 href 为可执行协议，点击即触发；
- 作品名设为 `</title><script>alert(1)</script>` 后导出 PDF，脚本进入文档。

## 修复
- `HelpPanel.js` 的链接渲染改为回调：仅当 URL 匹配 `^(https?:|mailto:)/i` 时才输出 `<a>` 标签，否则只输出纯文本（不生成可执行 href）；
- `settings-io.js` 导出 PDF 时对作品名的 `& < > " '` 做 HTML 转义后再写入 title。

## 验证（本地，单元验证）
- `javascript:` / `data:` / `vbscript:` 链接被中性化为纯文本，不再进入 href；
- 含特殊字符的作品名经转义后无法逃逸 `<title>`，`<script>` 注入被阻断；
- 普通 `http(s)` / `mailto` 链接渲染正常。

## 影响范围
- 修改文件：`app/components/HelpPanel.js`、`app/lib/settings-io.js`
- 帮助面板的合法链接与排版不变；导出 / 打印 PDF 的版式与内容不受影响（仅对标题做了转义）。