### PR TITLE
fix(security): parse-file 错误信息脱敏避免内部信息泄露 (V-08)

### DIFF
--- a/app/api/parse-file/route.js
+++ b/app/api/parse-file/route.js
@@ -46,8 +46,10 @@ export async function POST(request) {
         return NextResponse.json({ text });
     } catch (err) {
         console.error('parse-file error:', err);
+        // 不把解析库的原始错误/堆栈/文件路径回传前端，避免内部信息泄露；
+        // 仅返回稳定文案 + code，前端用 localizeApiError 按 code 本地化展示
         return NextResponse.json(
-            { error: `解析失败：${err.message}`, code: 'PARSE_FAILED', detail: err.message },
+            { error: '解析失败', code: 'PARSE_FAILED' },
             { status: 500 }
         );
     }


### PR DESCRIPTION
## 问题
`/api/parse-file` 解析失败时把解析库原始错误信息通过 `error` 与 `detail` 两个字段回传前端，前端 `localizeApiError` 还会把 `detail` 拼进用户可见提示，泄露 `pdf-parse` / `word-extractor` 的内部信息（可能含文件路径、库版本、堆栈或部分内容）。

## 根因
catch 块直接把 `err.message` 插值进响应并写入 `detail`。

## 复现（修复前 → 修复后）
```bash
# 修复前：损坏 PDF → 泄露内部错误
curl -X POST http://localhost:3000/api/parse-file -F 'file=@corrupt.pdf;filename=x.pdf'
# {"error":"解析失败：Invalid PDF structure","code":"PARSE_FAILED","detail":"Invalid PDF structure"}

# 修复后：脱敏
curl -X POST http://localhost:3000/api/parse-file -F 'file=@corrupt.pdf;filename=x.pdf'
# {"error":"解析失败","code":"PARSE_FAILED"}
```

## 修复
catch 块改为只返回稳定文案 `解析失败` + `code: PARSE_FAILED`，移除 `detail` 字段；服务端仍用 `console.error` 记录完整错误便于排查。

## 验证（本地）
- 损坏 PDF / 损坏 DOC → 仅返回 `{"error":"解析失败","code":"PARSE_FAILED"}`，无内部信息；
- 正常 PDF（真实文件）→ 正常解析，返回完整 `text`（实测 4265 字符），正常导入路径不受影响。

## 影响范围
- 修改文件：`app/api/parse-file/route.js`（仅 catch 块，成功解析路径逐字节未变）
- 正常 PDF / DOC 导入完全不受影响；仅脱敏失败时的错误回显。